### PR TITLE
refactor: [SIW-2505] Remove NFC permissions from `CieSDK` module

### DIFF
--- a/CieSDK/src/main/AndroidManifest.xml
+++ b/CieSDK/src/main/AndroidManifest.xml
@@ -1,10 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission android:name="android.permission.NFC" />
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-    <uses-feature
-        android:name="android.hardware.nfc"
-        android:required="false" />
-    <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
+
 </manifest>

--- a/README.md
+++ b/README.md
@@ -162,3 +162,13 @@ ATR reading:
     }
 )
 ```
+
+## Permissions
+
+To use this package you need to declare the following permission into your `AndroidManifest.xml`.
+More info in the [official Android documentation](https://developer.android.com/develop/connectivity/nfc/nfc):
+
+```xml
+    <!-- Required to access NFC hardware -->
+    <uses-permission android:name="android.permission.NFC" />
+```

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Required for auth URL retrieval -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Required to access NFC hardware -->
+    <uses-permission android:name="android.permission.NFC" />
+
     <application
         android:name=".Application"
         android:allowBackup="true"


### PR DESCRIPTION
## Short description

This PR moves the NFC permission management from the package to the app that must use the package (in this case the example app)

## List of changes proposed in this pull request

- Moved permissions from [CieSDK/src/main/AndroidManifest.xml](https://github.com/pagopa/cie-sdk-android/compare/SIW-2505?expand=1#diff-164cad16e0416cb34f3820a32006d2d29dd3720f302406a65dd4baa5b9b71895) to [app/src/main/AndroidManifest.xml](https://github.com/pagopa/cie-sdk-android/compare/SIW-2505?expand=1#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cd)
- Updated [README.md](https://github.com/pagopa/cie-sdk-android/compare/SIW-2505?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
- Removed unused Bluetooth permissions

## How to test

Ensure the test app works properly
