### PR TITLE
fix: [IOPID-2404] `javax.net.ssl.SSLHandshakeException` on different SDK provider

### DIFF
--- a/CieSDK/build.gradle.kts
+++ b/CieSDK/build.gradle.kts
@@ -43,7 +43,7 @@ android {
 }
 
 mavenPublishing {
-    coordinates("it.pagopa.io.app.cie", "cie", "0.1.4")
+    coordinates("it.pagopa.io.app.cie", "cie", "0.1.5")
 
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()

--- a/CieSDK/src/main/java/it/pagopa/io/app/cie/cie/key_store/CieProvider.kt
+++ b/CieSDK/src/main/java/it/pagopa/io/app/cie/cie/key_store/CieProvider.kt
@@ -3,14 +3,15 @@ package it.pagopa.io.app.cie.cie.key_store
 import android.os.Build
 import java.security.Provider
 
-internal class CieProvider : Provider(CieProvider::class.java.simpleName, 1.0, "Provider per cie") {
+internal class CieProvider : Provider(PROVIDER_NAME, 1.0, "Provider per cie") {
 
     companion object {
-        const val PROVIDER = "CIE"
+        const val PROVIDER_NAME = "CieProvider"
+        const val KEYSTORE_TYPE = "CIE"
     }
 
     init {
-        put("KeyStore.$PROVIDER", CieKeyStore::class.java.name)
+        put("KeyStore.$KEYSTORE_TYPE", CieKeyStore::class.java.name)
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             put("Signature.NONEwithRSA", CieSignatureImpl.None::class.java.name)
         } else {

--- a/CieSDK/src/main/java/it/pagopa/io/app/cie/network/NetworkClient.kt
+++ b/CieSDK/src/main/java/it/pagopa/io/app/cie/network/NetworkClient.kt
@@ -26,8 +26,10 @@ internal class NetworkClient(
     }
 
     private fun okhttpInitializer(): OkHttpClient {
-        Security.removeProvider(CieProvider.PROVIDER)
+        // Remove any previously installed instance of the provider
+        Security.removeProvider(CieProvider.PROVIDER_NAME)
         val cieProvider = CieProvider()
+        // A provider with the same name cannot be added if already installed
         Security.insertProviderAt(cieProvider, 1)
         val builder = OkHttpClient.Builder()
             .addInterceptor(loggingInterceptor)
@@ -35,7 +37,7 @@ internal class NetworkClient(
             .readTimeout(15, TimeUnit.SECONDS)
             .writeTimeout(15, TimeUnit.SECONDS)
 
-        val cieKeyStore: KeyStore = KeyStore.getInstance(CieProvider.PROVIDER)
+        val cieKeyStore: KeyStore = KeyStore.getInstance(CieProvider.KEYSTORE_TYPE)
         cieKeyStore.load(ByteArrayInputStream(certificate), null)
         val kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
         kmf.init(cieKeyStore, null)


### PR DESCRIPTION
## Short description

This PR fixes the issue with the security provider removal, as detailed in the [analysis document](https://pagopa.atlassian.net/wiki/spaces/IAEI/pages/1966932047/Analisi+per+verifica+possibile+convivenza+tra+SDK+CIE+old+e+new).

## List of changes proposed in this pull request

- Corrected the removal of the security provider by referencing its exact name.
- Bumped library version to `0.1.5`.

## How to test

1. Perform an EIC read process.
2. Verify that no regressions occur during the operation.
3. Confirm that the security provider is correctly handled and no unexpected removals happen.