### PR TITLE
feat: [SIW-000] doSound param

### DIFF
--- a/CieSDK/src/main/java/it/pagopa/io/app/cie/CieSDK.kt
+++ b/CieSDK/src/main/java/it/pagopa/io/app/cie/CieSDK.kt
@@ -68,11 +68,13 @@ class CieSDK private constructor() {
 
     /**It starts reading CIE
      * @param isoDepTimeout : Timeout to set on nfc reader
+     * @param doSound : Boolean to choose if sound should be played or not
      * @param callback : [NetworkCallback]
      * @throws Exception if setPin has not been called before*/
     @Throws(Exception::class)
     fun startReading(
         isoDepTimeout: Int,
+        doSound: Boolean,
         nfcListener: NfcEvents,
         callback: NetworkCallback
     ) {
@@ -90,32 +92,40 @@ class CieSDK private constructor() {
             idpNetworkCall.withReadCieJob(job)
         else
             throw Exception("You never call withUrl method to initialize the header!!")
-        readCie?.read(scope, isoDepTimeout, nfcListener, object : BaseReadCie.ReadingCieInterface {
-            override fun onTransmit(value: Boolean) {}
-            override fun <T> backResource(action: BaseReadCie.FunInterfaceResource<T>) {
-                if (action.status == FunInterfaceStatus.SUCCESS) {
-                    if (CieLogger.enabled) {
-                        val b64 = Base64.encodeToString(action.data as ByteArray, Base64.DEFAULT)
-                        CieLogger.i(tag, "CALLING REPOSITORY with $b64")
+        readCie?.read(
+            scope,
+            isoDepTimeout,
+            doSound,
+            nfcListener,
+            object : BaseReadCie.ReadingCieInterface {
+                override fun onTransmit(value: Boolean) {}
+                override fun <T> backResource(action: BaseReadCie.FunInterfaceResource<T>) {
+                    if (action.status == FunInterfaceStatus.SUCCESS) {
+                        if (CieLogger.enabled) {
+                            val b64 =
+                                Base64.encodeToString(action.data as ByteArray, Base64.DEFAULT)
+                            CieLogger.i(tag, "CALLING REPOSITORY with $b64")
+                        }
+                        idpNetworkCall.withCallback(callback) callWith action.data as ByteArray
+                    } else {
+                        CieLogger.e(
+                            tag,
+                            "PROCESS FINISHED WITH ERROR: ${action.nfcError?.msg ?: action.nfcError?.name}"
+                        )
                     }
-                    idpNetworkCall.withCallback(callback) callWith action.data as ByteArray
-                } else {
-                    CieLogger.e(
-                        tag,
-                        "PROCESS FINISHED WITH ERROR: ${action.nfcError?.msg ?: action.nfcError?.name}"
-                    )
                 }
-            }
-        })
+            })
     }
 
     /**It starts reading CIE to read Certificate Data
      * @param isoDepTimeout : Timeout to set on nfc reader
+     * @param doSound : Boolean to choose if sound should be played or not
      * @param callback : [CieCertificateDataCallback]
      * @throws Exception if setPin has not been called before*/
     @Throws(Exception::class)
     fun startReadingCertificate(
         isoDepTimeout: Int,
+        doSound: Boolean,
         nfcListener: NfcEvents,
         callback: CieCertificateDataCallback
     ) {
@@ -129,47 +139,54 @@ class CieSDK private constructor() {
             this.context!!,
             ciePin
         )
-        readCie?.read(scope, isoDepTimeout, nfcListener, object : BaseReadCie.ReadingCieInterface {
-            override fun onTransmit(value: Boolean) {}
+        readCie?.read(
+            scope,
+            isoDepTimeout,
+            doSound,
+            nfcListener,
+            object : BaseReadCie.ReadingCieInterface {
+                override fun onTransmit(value: Boolean) {}
 
-            @Suppress("DEPRECATION")//for X509Name...
-            override fun <T> backResource(action: BaseReadCie.FunInterfaceResource<T>) {
-                if (action.status == FunInterfaceStatus.SUCCESS) {
-                    val cieCertificate = action.data as ByteArray
-                    if (CieLogger.enabled) {
-                        val b64 = Base64.encodeToString(cieCertificate, Base64.DEFAULT)
-                        CieLogger.i(tag, "CERTIFICATE:\n $b64")
+                @Suppress("DEPRECATION")//for X509Name...
+                override fun <T> backResource(action: BaseReadCie.FunInterfaceResource<T>) {
+                    if (action.status == FunInterfaceStatus.SUCCESS) {
+                        val cieCertificate = action.data as ByteArray
+                        if (CieLogger.enabled) {
+                            val b64 = Base64.encodeToString(cieCertificate, Base64.DEFAULT)
+                            CieLogger.i(tag, "CERTIFICATE:\n $b64")
+                        }
+                        val certFactory = CertificateFactory.getInstance("X.509")
+                        val `in`: InputStream = ByteArrayInputStream(cieCertificate)
+                        val cert = certFactory.generateCertificate(`in`) as X509Certificate?
+                        val x509Principal = PrincipalUtil.getSubjectX509Principal(cert)
+                        val name = x509Principal.getValues(X509Name.GIVENNAME)
+                        val surname = x509Principal.getValues(X509Name.SURNAME)
+                        val serialNumber = x509Principal.getValues(X509Name.SERIALNUMBER)
+                        val fiscalCode = x509Principal.getValues(X509Name.CN)
+                        val dataBack = CertificateData(
+                            name = name.firstOrNull() as? String,
+                            surname = surname.firstOrNull() as? String,
+                            fiscalCode = fiscalCode.firstOrNull() as? String,
+                            docSerialNumber = serialNumber.firstOrNull() as? String
+                        )
+                        callback.onSuccess(dataBack)
+                    } else {
+                        callback.onError(action.nfcError ?: NfcError.GENERAL_EXCEPTION)
                     }
-                    val certFactory = CertificateFactory.getInstance("X.509")
-                    val `in`: InputStream = ByteArrayInputStream(cieCertificate)
-                    val cert = certFactory.generateCertificate(`in`) as X509Certificate?
-                    val x509Principal = PrincipalUtil.getSubjectX509Principal(cert)
-                    val name = x509Principal.getValues(X509Name.GIVENNAME)
-                    val surname = x509Principal.getValues(X509Name.SURNAME)
-                    val serialNumber = x509Principal.getValues(X509Name.SERIALNUMBER)
-                    val fiscalCode = x509Principal.getValues(X509Name.CN)
-                    val dataBack = CertificateData(
-                        name = name.firstOrNull() as? String,
-                        surname = surname.firstOrNull() as? String,
-                        fiscalCode = fiscalCode.firstOrNull() as? String,
-                        docSerialNumber = serialNumber.firstOrNull() as? String
-                    )
-                    callback.onSuccess(dataBack)
-                } else {
-                    callback.onError(action.nfcError ?: NfcError.GENERAL_EXCEPTION)
                 }
-            }
-        })
+            })
     }
 
     /**It starts reading CIE Atr to read CIE TYPE
      * @param isoDepTimeout  Timeout to set on nfc reader
+     * @param doSound : Boolean to choose if sound should be played or not
      * @param nfcListener [NfcEvents]
      * @param callback [CieAtrCallback]
      * @throws Exception if context is not initialized*/
     @Throws(Exception::class)
     fun startReadingCieAtr(
         isoDepTimeout: Int,
+        doSound: Boolean,
         nfcListener: NfcEvents,
         callback: CieAtrCallback
     ) {
@@ -181,6 +198,7 @@ class CieSDK private constructor() {
         readCie?.readCieAtr(
             scope,
             isoDepTimeout,
+            doSound = doSound,
             nfcListener,
             object : BaseReadCie.ReadingCieInterface {
                 override fun onTransmit(value: Boolean) {}
@@ -199,12 +217,14 @@ class CieSDK private constructor() {
     /**It starts reading CIE to read [InternalAuthenticationResponse]
      * @param challenge  Challenge to be signed
      * @param isoDepTimeout  Timeout to set on nfc reader
+     * @param doSound : Boolean to choose if sound should be played or not
      * @param nfcListener [NfcEvents]
      * @param callback [NisCallback]
      * @throws Exception if context is not initialized*/
     fun startReadingNis(
         challenge: String,
         isoDepTimeout: Int,
+        doSound: Boolean,
         nfcListener: NfcEvents,
         callback: NisCallback
     ) {
@@ -217,6 +237,7 @@ class CieSDK private constructor() {
             challenge = challenge,
             scope = scope,
             isoDepTimeout = isoDepTimeout,
+            doSound = doSound,
             nfcListener = nfcListener,
             object : BaseReadCie.ReadingCieInterface {
                 override fun onTransmit(value: Boolean) {}
@@ -235,12 +256,14 @@ class CieSDK private constructor() {
     /**It starts reading CIE to perform Pace flow and giving back [MRTDResponse]
      * @param can CIE CAN from user
      * @param isoDepTimeout  Timeout to set on nfc reader
+     * @param doSound : Boolean to choose if sound should be played or not
      * @param nfcListener [NfcEvents]
      * @param callback [NisCallback]
      * @throws Exception if context is not initialized*/
     fun startDoPace(
         can: String,
         isoDepTimeout: Int,
+        doSound: Boolean,
         nfcListener: NfcEvents,
         callback: PaceCallback
     ) {
@@ -253,6 +276,7 @@ class CieSDK private constructor() {
             can = can,
             scope = scope,
             isoDepTimeout = isoDepTimeout,
+            doSound = doSound,
             nfcListener = nfcListener,
             object : BaseReadCie.ReadingCieInterface {
                 override fun onTransmit(value: Boolean) {}
@@ -271,6 +295,7 @@ class CieSDK private constructor() {
      * @param challenge Challenge to be signed
      * @param can CIE CAN from user
      * @param isoDepTimeout  Timeout to set on nfc reader
+     * @param doSound : Boolean to choose if sound should be played or not
      * @param nfcListener [NfcEvents]
      * @param callback [NisCallback]
      * @throws Exception if context is not initialized*/
@@ -278,6 +303,7 @@ class CieSDK private constructor() {
         challenge: String,
         can: String,
         isoDepTimeout: Int,
+        doSound: Boolean,
         nfcListener: NfcEvents,
         callback: NisAndPaceCallback
     ) {
@@ -291,6 +317,7 @@ class CieSDK private constructor() {
             can = can,
             scope = scope,
             isoDepTimeout = isoDepTimeout,
+            doSound = doSound,
             nfcListener = nfcListener,
             object : BaseReadCie.ReadingCieInterface {
                 override fun onTransmit(value: Boolean) {}

--- a/CieSDK/src/main/java/it/pagopa/io/app/cie/nfc/BaseNfcImpl.kt
+++ b/CieSDK/src/main/java/it/pagopa/io/app/cie/nfc/BaseNfcImpl.kt
@@ -7,6 +7,7 @@ internal abstract class BaseNfcImpl {
     lateinit var readingInterface: NfcReading
     abstract fun connect(
         isoDepTimeout: Int,
+        doSound: Boolean,
         onTagDiscovered: () -> Unit,
         actionDone: () -> Unit
     )
@@ -15,10 +16,11 @@ internal abstract class BaseNfcImpl {
     abstract fun disconnect()
     fun transmit(
         isoDepTimeout: Int,
+        doSound: Boolean,
         pin: String,
         onTagDiscovered: () -> Unit,
     ) {
-        connect(isoDepTimeout, onTagDiscovered) {
+        connect(isoDepTimeout, doSound, onTagDiscovered) {
             readingInterface.onTransmit(NfcEvent.CONNECTED)
             readCie.read(pin)
         }
@@ -26,9 +28,10 @@ internal abstract class BaseNfcImpl {
 
     fun readCieAtr(
         isoDepTimeout: Int,
+        doSound: Boolean,
         onTagDiscovered: () -> Unit
     ) {
-        connect(isoDepTimeout, onTagDiscovered) {
+        connect(isoDepTimeout, doSound, onTagDiscovered) {
             readingInterface.onTransmit(NfcEvent.CONNECTED)
             readCie.readCieAtr()
         }
@@ -37,9 +40,10 @@ internal abstract class BaseNfcImpl {
     fun readNis(
         challenge: String,
         isoDepTimeout: Int,
+        doSound: Boolean,
         onTagDiscovered: () -> Unit
     ) {
-        connect(isoDepTimeout, onTagDiscovered) {
+        connect(isoDepTimeout, doSound, onTagDiscovered) {
             readingInterface.onTransmit(NfcEvent.CONNECTED)
             readCie.readNis(challenge)
         }
@@ -48,9 +52,10 @@ internal abstract class BaseNfcImpl {
     fun doPace(
         can: String,
         isoDepTimeout: Int,
+        doSound: Boolean,
         onTagDiscovered: () -> Unit
     ) {
-        connect(isoDepTimeout, onTagDiscovered) {
+        connect(isoDepTimeout, doSound, onTagDiscovered) {
             readingInterface.onTransmit(NfcEvent.CONNECTED)
             readCie.doPace(can)
         }
@@ -60,9 +65,10 @@ internal abstract class BaseNfcImpl {
         challenge: String,
         can: String,
         isoDepTimeout: Int,
+        doSound: Boolean,
         onTagDiscovered: () -> Unit
     ) {
-        connect(isoDepTimeout, onTagDiscovered) {
+        connect(isoDepTimeout, doSound, onTagDiscovered) {
             readingInterface.onTransmit(NfcEvent.CONNECTED)
             readCie.nisAndPace(challenge, can)
         }

--- a/CieSDK/src/main/java/it/pagopa/io/app/cie/nfc/BaseReadCie.kt
+++ b/CieSDK/src/main/java/it/pagopa/io/app/cie/nfc/BaseReadCie.kt
@@ -23,11 +23,12 @@ abstract class BaseReadCie(
     fun read(
         scope: CoroutineScope,
         isoDepTimeout: Int,
+        doSound: Boolean,
         nfcListener: NfcEvents,
         readingInterface: ReadingCieInterface
     ) {
         scope.launch {
-            workNfc(isoDepTimeout, pin.orEmpty(), object : NfcReading {
+            workNfc(isoDepTimeout, doSound, pin.orEmpty(), object : NfcReading {
                 override fun onTransmit(message: NfcEvent) {
                     CieLogger.i("message from CIE", message.name)
                     nfcListener.event(message)
@@ -54,11 +55,12 @@ abstract class BaseReadCie(
     fun readCieAtr(
         scope: CoroutineScope,
         isoDepTimeout: Int,
+        doSound: Boolean,
         nfcListener: NfcEvents,
         readingInterface: ReadingCieInterface
     ) {
         scope.launch {
-            workNfcForCieAtr(isoDepTimeout, object : NfcReading {
+            workNfcForCieAtr(isoDepTimeout, doSound, object : NfcReading {
                 override fun onTransmit(message: NfcEvent) {
                     CieLogger.i("message from CIE", message.name)
                     nfcListener.event(message)
@@ -86,6 +88,7 @@ abstract class BaseReadCie(
         challenge: String,
         scope: CoroutineScope,
         isoDepTimeout: Int,
+        doSound: Boolean,
         nfcListener: NfcEvents,
         readingInterface: ReadingCieInterface
     ) {
@@ -93,6 +96,7 @@ abstract class BaseReadCie(
             workNfcForNis(
                 challenge,
                 isoDepTimeout,
+                doSound,
                 object : NfcReading {
                     override fun onTransmit(message: NfcEvent) {
                         CieLogger.i("message from CIE", message.name)
@@ -120,6 +124,7 @@ abstract class BaseReadCie(
         can: String,
         scope: CoroutineScope,
         isoDepTimeout: Int,
+        doSound: Boolean,
         nfcListener: NfcEvents,
         readingInterface: ReadingCieInterface
     ) {
@@ -127,6 +132,7 @@ abstract class BaseReadCie(
             workNfcForPace(
                 can,
                 isoDepTimeout,
+                doSound,
                 object : NfcReading {
                     override fun onTransmit(message: NfcEvent) {
                         CieLogger.i("message from CIE", message.name)
@@ -155,6 +161,7 @@ abstract class BaseReadCie(
         can: String,
         scope: CoroutineScope,
         isoDepTimeout: Int,
+        doSound: Boolean,
         nfcListener: NfcEvents,
         readingInterface: ReadingCieInterface
     ) {
@@ -163,6 +170,7 @@ abstract class BaseReadCie(
                 challenge,
                 can,
                 isoDepTimeout,
+                doSound,
                 object : NfcReading {
                     override fun onTransmit(message: NfcEvent) {
                         CieLogger.i("message from CIE", message.name)
@@ -188,6 +196,7 @@ abstract class BaseReadCie(
 
     internal abstract suspend fun workNfc(
         isoDepTimeout: Int,
+        doSound: Boolean,
         pin: String,
         readingInterface: NfcReading,
         onTagDiscovered: () -> Unit
@@ -195,6 +204,7 @@ abstract class BaseReadCie(
 
     internal abstract suspend fun workNfcForCieAtr(
         isoDepTimeout: Int,
+        doSound: Boolean,
         readingInterface: NfcReading,
         onTagDiscovered: () -> Unit
     )
@@ -202,6 +212,7 @@ abstract class BaseReadCie(
     internal abstract suspend fun workNfcForNis(
         challenge: String,
         isoDepTimeout: Int,
+        doSound: Boolean,
         readingInterface: NfcReading,
         onTagDiscovered: () -> Unit
     )
@@ -209,6 +220,7 @@ abstract class BaseReadCie(
     internal abstract suspend fun workNfcForPace(
         can: String,
         isoDepTimeout: Int,
+        doSound: Boolean,
         readingInterface: NfcReading,
         onTagDiscovered: () -> Unit
     )
@@ -217,6 +229,7 @@ abstract class BaseReadCie(
         challenge: String,
         can: String,
         isoDepTimeout: Int,
+        doSound: Boolean,
         readingInterface: NfcReading,
         onTagDiscovered: () -> Unit
     )

--- a/CieSDK/src/main/java/it/pagopa/io/app/cie/nfc/NfcImpl.kt
+++ b/CieSDK/src/main/java/it/pagopa/io/app/cie/nfc/NfcImpl.kt
@@ -11,6 +11,7 @@ import it.pagopa.io.app.cie.cie.OnTransmit
 import it.pagopa.io.app.cie.cie.ReadCie
 import it.pagopa.io.app.cie.cie.transmitLogic
 import it.pagopa.io.app.cie.findActivity
+import kotlin.or
 
 internal class NfcImpl private constructor() : BaseNfcImpl() {
     private var adapter: NfcAdapter? = null
@@ -30,15 +31,13 @@ internal class NfcImpl private constructor() : BaseNfcImpl() {
         actionDone: () -> Unit
     ) {
         val activity = context.findActivity()
-        val flags = if (doSound)
-            NfcAdapter.FLAG_READER_NFC_A or
-                    NfcAdapter.FLAG_READER_NFC_B or
-                    NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK
-        else
-            NfcAdapter.FLAG_READER_NFC_A or
-                    NfcAdapter.FLAG_READER_NFC_B or
-                    NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK or
-                    NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS
+        var flags = NfcAdapter.FLAG_READER_NFC_A or
+                NfcAdapter.FLAG_READER_NFC_B or
+                NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK
+        if (!doSound)
+            flags = flags or NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS
+        if (android.os.Build.VERSION.SDK_INT >= 35)
+            flags = flags or NfcAdapter.FLAG_LISTEN_DISABLE
         try {
             adapter?.enableReaderMode(
                 activity, {

--- a/CieSDK/src/main/java/it/pagopa/io/app/cie/nfc/NfcImpl.kt
+++ b/CieSDK/src/main/java/it/pagopa/io/app/cie/nfc/NfcImpl.kt
@@ -11,7 +11,6 @@ import it.pagopa.io.app.cie.cie.OnTransmit
 import it.pagopa.io.app.cie.cie.ReadCie
 import it.pagopa.io.app.cie.cie.transmitLogic
 import it.pagopa.io.app.cie.findActivity
-import kotlin.or
 
 internal class NfcImpl private constructor() : BaseNfcImpl() {
     private var adapter: NfcAdapter? = null
@@ -36,8 +35,6 @@ internal class NfcImpl private constructor() : BaseNfcImpl() {
                 NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK
         if (!doSound)
             flags = flags or NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS
-        if (android.os.Build.VERSION.SDK_INT >= 35)
-            flags = flags or NfcAdapter.FLAG_LISTEN_DISABLE
         try {
             adapter?.enableReaderMode(
                 activity, {

--- a/CieSDK/src/main/java/it/pagopa/io/app/cie/nfc/NfcImpl.kt
+++ b/CieSDK/src/main/java/it/pagopa/io/app/cie/nfc/NfcImpl.kt
@@ -23,10 +23,22 @@ internal class NfcImpl private constructor() : BaseNfcImpl() {
         this.adapter = NfcAdapter.getDefaultAdapter(context)
     }
 
-    override fun connect(isoDepTimeout: Int,
-                         onTagDiscovered: () -> Unit,
-                         actionDone: () -> Unit) {
+    override fun connect(
+        isoDepTimeout: Int,
+        doSound: Boolean,
+        onTagDiscovered: () -> Unit,
+        actionDone: () -> Unit
+    ) {
         val activity = context.findActivity()
+        val flags = if (doSound)
+            NfcAdapter.FLAG_READER_NFC_A or
+                    NfcAdapter.FLAG_READER_NFC_B or
+                    NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK
+        else
+            NfcAdapter.FLAG_READER_NFC_A or
+                    NfcAdapter.FLAG_READER_NFC_B or
+                    NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK or
+                    NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS
         try {
             adapter?.enableReaderMode(
                 activity, {
@@ -45,10 +57,7 @@ internal class NfcImpl private constructor() : BaseNfcImpl() {
                         disconnect()
                         readingInterface.error(NfcError.FAIL_TO_CONNECT_WITH_TAG)
                     }
-                }, NfcAdapter.FLAG_READER_NFC_A or
-                        NfcAdapter.FLAG_READER_NFC_B or
-                        NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK or
-                        NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS,
+                }, flags,
                 null
             )
         } catch (throwable: Throwable) {

--- a/CieSDK/src/main/java/it/pagopa/io/app/cie/nfc/ReadCIE.kt
+++ b/CieSDK/src/main/java/it/pagopa/io/app/cie/nfc/ReadCIE.kt
@@ -12,6 +12,7 @@ internal class ReadCIE(
     private var implementation: NfcImpl? = null
     override suspend fun workNfc(
         isoDepTimeout: Int,
+        doSound: Boolean,
         pin: String,
         readingInterface: NfcReading,
         onTagDiscovered: () -> Unit
@@ -19,7 +20,7 @@ internal class ReadCIE(
         withContext(Dispatchers.Default) {
             implementation = NfcImpl(context, readingInterface)
             try {
-                implementation!!.transmit(isoDepTimeout, pin, onTagDiscovered)
+                implementation!!.transmit(isoDepTimeout, doSound, pin, onTagDiscovered)
             } catch (e: Exception) {
                 readingInterface.error(NfcError.GENERAL_EXCEPTION.apply {
                     this.msg = e.message.orEmpty()
@@ -30,13 +31,14 @@ internal class ReadCIE(
 
     override suspend fun workNfcForCieAtr(
         isoDepTimeout: Int,
+        doSound: Boolean,
         readingInterface: NfcReading,
         onTagDiscovered: () -> Unit
     ) {
         withContext(Dispatchers.Default) {
             implementation = NfcImpl(context, readingInterface)
             try {
-                implementation!!.readCieAtr(isoDepTimeout, onTagDiscovered)
+                implementation!!.readCieAtr(isoDepTimeout, doSound, onTagDiscovered)
             } catch (e: Exception) {
                 readingInterface.error(NfcError.GENERAL_EXCEPTION.apply {
                     this.msg = e.message.orEmpty()
@@ -48,13 +50,14 @@ internal class ReadCIE(
     override suspend fun workNfcForNis(
         challenge: String,
         isoDepTimeout: Int,
+        doSound: Boolean,
         readingInterface: NfcReading,
         onTagDiscovered: () -> Unit
     ) {
         withContext(Dispatchers.Default) {
             implementation = NfcImpl(context, readingInterface)
             try {
-                implementation!!.readNis(challenge, isoDepTimeout, onTagDiscovered)
+                implementation!!.readNis(challenge, isoDepTimeout, doSound, onTagDiscovered)
             } catch (e: Exception) {
                 readingInterface.error(NfcError.GENERAL_EXCEPTION.apply {
                     this.msg = e.message.orEmpty()
@@ -66,13 +69,14 @@ internal class ReadCIE(
     override suspend fun workNfcForPace(
         can: String,
         isoDepTimeout: Int,
+        doSound: Boolean,
         readingInterface: NfcReading,
         onTagDiscovered: () -> Unit
     ) {
         withContext(Dispatchers.Default) {
             implementation = NfcImpl(context, readingInterface)
             try {
-                implementation!!.doPace(can, isoDepTimeout, onTagDiscovered)
+                implementation!!.doPace(can, isoDepTimeout, doSound, onTagDiscovered)
             } catch (e: Exception) {
                 readingInterface.error(NfcError.GENERAL_EXCEPTION.apply {
                     this.msg = e.message.orEmpty()
@@ -82,16 +86,23 @@ internal class ReadCIE(
     }
 
     override suspend fun workNfcForNisAndPace(
-        challenge:String,
+        challenge: String,
         can: String,
         isoDepTimeout: Int,
+        doSound: Boolean,
         readingInterface: NfcReading,
         onTagDiscovered: () -> Unit
     ) {
         withContext(Dispatchers.Default) {
             implementation = NfcImpl(context, readingInterface)
             try {
-                implementation!!.doNisAndPace(challenge,can, isoDepTimeout, onTagDiscovered)
+                implementation!!.doNisAndPace(
+                    challenge,
+                    can,
+                    isoDepTimeout,
+                    doSound,
+                    onTagDiscovered
+                )
             } catch (e: Exception) {
                 readingInterface.error(NfcError.GENERAL_EXCEPTION.apply {
                     this.msg = e.message.orEmpty()

--- a/CieSDK/src/test/java/it/pagopa/io/app/cie/CieCommandsTest.kt
+++ b/CieSDK/src/test/java/it/pagopa/io/app/cie/CieCommandsTest.kt
@@ -29,7 +29,7 @@ class CieCommandsTest {
         }
     }
     private val onTransmitApduTest = object : OnTransmit {
-        override fun sendCommand(apdu: ByteArray,nfcEvents: NfcEvent): ApduResponse {
+        override fun sendCommand(apdu: ByteArray, nfcEvents: NfcEvent): ApduResponse {
             return if (nfcEvents == NfcEvent.INTERNAL_AUTHENTICATION)
                 ApduResponse(
                     Utils.hexStringToByteArray("back_from_test"),
@@ -155,12 +155,13 @@ class CieCommandsTest {
         MyNfcImpl(object : NfcReading {
             override fun error(error: NfcError) {
             }
+
             override fun onTransmit(message: NfcEvent) {
             }
 
             override fun <T> read(element: T) {
             }
-        }, onTransmit).transmit(10000, "ch"){
+        }, onTransmit).transmit(10000, false, "ch") {
 
         }
     }
@@ -185,7 +186,12 @@ class CieCommandsTest {
     fun sendApduDataEmptyTest() {
         val commands = ApduManager(onTransmitApduTest)
         val response =
-            commands.sendApdu(byteArrayOf(0x00), byteArrayOf(), null, NfcEvent.INTERNAL_AUTHENTICATION)
+            commands.sendApdu(
+                byteArrayOf(0x00),
+                byteArrayOf(),
+                null,
+                NfcEvent.INTERNAL_AUTHENTICATION
+            )
         assert(Utils.bytesToString(response.swByte) == "9000")
     }
 
@@ -238,7 +244,7 @@ class CieCommandsTest {
 
             override fun error(error: NfcError) {
             }
-        }, onTransmitForException).transmit(1000, "ch"){
+        }, onTransmitForException).transmit(1000, false, "ch") {
 
         }
     }
@@ -268,6 +274,7 @@ class CieCommandsTest {
 
         override fun connect(
             isoDepTimeout: Int,
+            doSound: Boolean,
             onTagDiscovered: () -> Unit,
             actionDone: () -> Unit
         ) {

--- a/README.md
+++ b/README.md
@@ -151,11 +151,12 @@ These above are all the events while reading CIE. This enum has still two compan
 That's why all of these events have one of or both numerator and numeratorKindOf property.
 
 ## Example usage
+P.N.: For every flow you've got a param called doSound. Set to true if you want platform sound.
 Authentication:
 ```kotlin
 try {
     cieSdk.setPin(pin)
-    cieSdk.startReading(isoDepTimeout= 10000, object : NfcEvents {
+    cieSdk.startReading(isoDepTimeout = 10000, doSound = true, object : NfcEvents {
         override fun error(error: NfcError) {
             //ERROR OCCURRED!!
         }
@@ -184,6 +185,7 @@ ATR reading:
 ```kotlin
  cieSdk.startReadingCieAtr(
     isoDepTimeout= 10000,
+    doSound = true,
     object : NfcEvents {
         override fun error(error: NfcError) {
             //ERROR OCCURRED!!
@@ -207,6 +209,7 @@ NIS (Internal authentication) reading:
 ```kotlin
  cieSdk.startReadingNis(
     challenge = challenge.value,
+    doSound = true,
     isoDepTimeout = 10000,
     object : NfcEvents {
         override fun error(error: NfcError) {
@@ -244,6 +247,7 @@ PACE flow:
  cieSdk.startDoPace(
     can = can.value,
     isoDepTimeout = 10000,
+    doSound = true,
     object : NfcEvents {
         override fun error(error: NfcError) {
             //ERROR OCCURRED!!
@@ -309,6 +313,7 @@ cieSdk.startNisAndPace(
     challenge = challenge.value,
     can = can.value,
     isoDepTimeout = 10000,
+    doSound = true,
     object : NfcEvents {
         override fun error(error: NfcError) {
             //ERROR OCCURRED!!

--- a/app/src/main/java/it/pagopa/io/app/cie_example/ui/view_model/CieSdkMethodsViewModel.kt
+++ b/app/src/main/java/it/pagopa/io/app/cie_example/ui/view_model/CieSdkMethodsViewModel.kt
@@ -107,7 +107,7 @@ class CieSdkMethodsViewModel(
     override fun readCie() {
         cieSdk.startReadingCieAtr(
             10000,
-            object : NfcEvents {
+            false,object : NfcEvents {
                 override fun error(error: NfcError) {
                     this@CieSdkMethodsViewModel.onError(error)
                 }

--- a/app/src/main/java/it/pagopa/io/app/cie_example/ui/view_model/NisAndPaceViewModel.kt
+++ b/app/src/main/java/it/pagopa/io/app/cie_example/ui/view_model/NisAndPaceViewModel.kt
@@ -21,6 +21,7 @@ class NisAndPaceViewModel(
             challenge = challenge.value,
             can = can.value,
             isoDepTimeout = 10000,
+            true,
             object : NfcEvents {
                 override fun error(error: NfcError) {
                     this@NisAndPaceViewModel.onError(error)

--- a/app/src/main/java/it/pagopa/io/app/cie_example/ui/view_model/PaceViewModel.kt
+++ b/app/src/main/java/it/pagopa/io/app/cie_example/ui/view_model/PaceViewModel.kt
@@ -19,6 +19,7 @@ class PaceViewModel(
         this.cieSdk.startDoPace(
             can = can.value,
             isoDepTimeout = 10000,
+            true,
             object : NfcEvents {
                 override fun error(error: NfcError) {
                     this@PaceViewModel.onError(error)

--- a/app/src/main/java/it/pagopa/io/app/cie_example/ui/view_model/ReadCieCertificateViewModel.kt
+++ b/app/src/main/java/it/pagopa/io/app/cie_example/ui/view_model/ReadCieCertificateViewModel.kt
@@ -18,7 +18,7 @@ class ReadCieCertificateViewModel(
     ) {
         try {
             cieSdk.setPin(pin)
-            cieSdk.startReadingCertificate(10000, object : NfcEvents {
+            cieSdk.startReadingCertificate(10000, true,object : NfcEvents {
                 override fun error(error: NfcError) {
                     this@ReadCieCertificateViewModel.onError(error)
                 }

--- a/app/src/main/java/it/pagopa/io/app/cie_example/ui/view_model/ReadCieViewModel.kt
+++ b/app/src/main/java/it/pagopa/io/app/cie_example/ui/view_model/ReadCieViewModel.kt
@@ -43,7 +43,7 @@ class ReadCieViewModel(
     ) {
         try {
             cieSdk.setPin(pin)
-            cieSdk.startReading(10000, object : NfcEvents {
+            cieSdk.startReading(10000, true, object : NfcEvents {
                 override fun error(error: NfcError) {
                     this@ReadCieViewModel.onError(error)
                 }

--- a/app/src/main/java/it/pagopa/io/app/cie_example/ui/view_model/ReadNisViewModel.kt
+++ b/app/src/main/java/it/pagopa/io/app/cie_example/ui/view_model/ReadNisViewModel.kt
@@ -18,6 +18,7 @@ class ReadNisViewModel(
         this.cieSdk.startReadingNis(
             challenge = challenge.value,
             isoDepTimeout = 10000,
+            true,
             object : NfcEvents {
                 override fun error(error: NfcError) {
                     this@ReadNisViewModel.onError(error)


### PR DESCRIPTION
## Short description

For every flow now you've got a param called doSound. Set to true if you want platform sound.

Example ATR reading:
```kotlin
 cieSdk.startReadingCieAtr(
    isoDepTimeout= 10000,
    doSound = true,
    object : NfcEvents {
        override fun error(error: NfcError) {
            //ERROR OCCURRED!!
        }

        override fun event(event: NfcEvent) {
            //EVENT OCCURRED!!
        }
    }, object : CieAtrCallback {
        override fun onSuccess(atr: ByteArray) {
            //ALL SUCCESS
        }

        override fun onError(error: NfcError) {
            //ERROR OCCURRED!!
        }
    }
)
```
